### PR TITLE
Add basic support for PR templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ brew install keith/formulae/git-pile
   you change this after using `git-pile` to create a PR, your PRs
   created before setting the prefix will not be updatable with the other
   commands.
+- Set `GIT_PILE_USE_PR_TEMPLATE` in your shell environment if you'd like
+  `git-pile` to attempt to prefill the description of your PR with the [PR
+  template][template] file if it exists.
+
+[template]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
 
 ## Advanced usage
 

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -84,7 +84,18 @@ elif git -C "$worktree_dir" push --quiet --set-upstream origin "$branch_name" 2>
   elif command -v gh > /dev/null; then
     # TODO: does gh not support -C either?
     pushd "$worktree_dir" >/dev/null
-    url=$(gh pr create --fill --base "$remote_branch_name" "$@" | grep github.com)
+    body_args=(--fill)
+    if [[ -n ${GIT_PILE_USE_PR_TEMPLATE:-} && -f .github/pull_request_template.md ]]; then
+      subject=$(git -C "$worktree_dir" show -s --format=%s HEAD)
+      body=$(git -C "$worktree_dir" show -s --format=%b HEAD)
+      if [[ -n "$body" ]]; then
+        body=$(printf '%s\n\n%s' "$body" "$(cat .github/pull_request_template.md)")
+      else
+        body="$(cat .github/pull_request_template.md)"
+      fi
+      body_args=(--title "$subject" --body "$body")
+    fi
+    url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "$@" | grep github.com)
     native_open "$url"
     popd >/dev/null
   else


### PR DESCRIPTION
This changes submitpr to read the default PR template file if
GIT_PILE_USE_PR_TEMPLATE is set. The trade offs here are generally
around how many clicks you want to have to do, vs how much you care
about PR template customization. Currently this only handles the single
default PR template, and it chooses to avoid all prompts by just
pre-filling the entire file, forcing you to fill out any parts of it on
the web. It also still includes the commit message body at the top of
the PR description.