### PR TITLE
Handle PR creation failure cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ brew install keith/formulae/git-pile
 - Set `GIT_PILE_USE_PR_TEMPLATE` in your shell environment if you'd like
   `git-pile` to attempt to prefill the description of your PR with the [PR
   template][template] file if it exists.
+- Run `git config --global pile.cleanupRemoteOnSubmitFailure true` to
+  automatically delete remote branches that mirror your local branch
+  when submitting the PR fails. This makes it easier to run `git
+  submitpr` again in the case you had a networking issue that causes the
+  submission to fail. This is off by default to avoid potentially
+  deleting a remote branch that somehow has commits that aren't on the
+  local branch.
 
 [template]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
 

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -72,6 +72,14 @@ native_open () {
   fi
 }
 
+cleanup_remote_branch() {
+  echo "error: failed to create PR, deleting remote branch..." >&2
+  git -C "$worktree_dir" push --quiet --delete origin "$branch_name" || true
+  _detach_branch
+  git branch -D "$branch_name"
+  exit 1
+}
+
 error_file=$(mktemp)
 if git -C "$worktree_dir" remote get-url mine 2>/dev/null && git -C "$worktree_dir" push --quiet --set-upstream mine "$branch_name"; then
   if command -v gh >/dev/null; then
@@ -84,7 +92,10 @@ elif git -C "$worktree_dir" push --quiet --set-upstream origin "$branch_name" 2>
   if command -v ghb > /dev/null; then
     # TODO maybe ghb should support -C ?
     pushd "$worktree_dir" >/dev/null
-    ghb pr --no-edit "$remote_branch_name" "$@"
+    if ! ghb pr --no-edit "$remote_branch_name" "$@"; then
+      cleanup_remote_branch
+    fi
+
     popd >/dev/null
   elif command -v gh > /dev/null; then
     # TODO: does gh not support -C either?
@@ -100,8 +111,13 @@ elif git -C "$worktree_dir" push --quiet --set-upstream origin "$branch_name" 2>
       fi
       body_args=(--title "$subject" --body "$body")
     fi
-    url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "$@" | grep github.com)
-    native_open "$url"
+
+    if url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "$@" | grep github.com); then
+      native_open "$url"
+    else
+      cleanup_remote_branch
+    fi
+
     popd >/dev/null
   else
     echo "error: no tool to create a PR, install gh: https://cli.github.com/" >&2

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -73,6 +73,10 @@ native_open () {
 }
 
 cleanup_remote_branch() {
+  if [[ "$(git config --default false --type=bool pile.cleanupRemoteOnSubmitFailure)" != true ]]; then
+    return
+  fi
+
   echo "error: failed to create PR, deleting remote branch..." >&2
   git -C "$worktree_dir" push --quiet --delete origin "$branch_name" || true
   _detach_branch


### PR DESCRIPTION
This is a bit risky since it deletes the remote branch as well in this
case, but if you just passed an invalid argument, or don't have network
access, without this cleanup you would have to do that yourself before
submitting the PR again. It should always be safe because if the branch
already existed upstream it would likely fail to be pushed to.