### PR TITLE
Move worktree path to single place

### DIFF
--- a/bin/git-pileworktreepath
+++ b/bin/git-pileworktreepath
@@ -5,7 +5,9 @@ set -euo pipefail
 # Get the primary clone's path in the case of using worktrees
 root=$(git worktree list --porcelain | head -1 | cut -d" " -f2)
 if [[ $OSTYPE == darwin* ]]; then
-  echo "$root" | md5
+  worktree_name=$(echo "$root" | md5)
 else
-  echo "$root" | md5sum | cut -d" " -f1
+  worktree_name=$(echo "$root" | md5sum | cut -d" " -f1)
 fi
+
+echo "$HOME/.cache/git-pile/$worktree_name"

--- a/bin/git-rebasepr
+++ b/bin/git-rebasepr
@@ -13,8 +13,7 @@ if ! git show-ref --quiet "$branch_name"; then
   exit 1
 fi
 
-worktree_name=$(git roothash)
-readonly worktree_dir="$HOME/.cache/git-pile/$worktree_name"
+worktree_dir="$(git pileworktreepath)"
 if [[ ! -d "$worktree_dir" ]]; then
   git worktree add -f "$worktree_dir" "$branch_name"
 else

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -27,8 +27,7 @@ remote_branch_name="${branch_with_remote#*/}"
 
 git branch --no-track "$branch_name" "@{upstream}"
 
-worktree_name=$(git roothash)
-readonly worktree_dir="$HOME/.cache/git-pile/$worktree_name"
+worktree_dir="$(git pileworktreepath)"
 if [[ ! -d "$worktree_dir" ]]; then
   git worktree add -f "$worktree_dir" "$branch_name"
 else

--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -43,8 +43,7 @@ if ! git show-ref --quiet "$branch_name"; then
   exit 1
 fi
 
-worktree_name=$(git roothash)
-readonly worktree_dir="$HOME/.cache/git-pile/$worktree_name"
+worktree_dir="$(git pileworktreepath)"
 if [[ ! -d "$worktree_dir" ]]; then
   git worktree add -f "$worktree_dir" "$branch_name"
 else


### PR DESCRIPTION
This was unnecessary duplication of the cache path