### PR TITLE
Abort cherry pick if cherry picked commit is empty

### DIFF
--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -88,11 +88,13 @@ fi
 if ! git -C "$worktree_dir" cherry-pick "$new_refspec^..$base_refspec"; then
   # TODO if you exit in vim with :cq, it asks you if it was successful, i think if you hit yes it will continue even if it's not?
   if git -C "$worktree_dir" mergetool; then
-    # TODO: Should this --allow-empty? I think i hit this when i updated a branch remotely and then pulled it locally
-    git -C "$worktree_dir" -c core.editor=true cherry-pick --continue
+    if ! git -C "$worktree_dir" -c core.editor=true cherry-pick --continue; then
+      git -C "$worktree_dir" cherry-pick --abort
+      echo "error: failed to cherry pick anything, was the commit you're adding empty on this branch?" >&2
+      exit 1
+    fi
   else
     git -C "$worktree_dir" cherry-pick --abort
-    # TODO what do i do? i think we have to reset branch state? maybe just abort cherry pick?
     exit 1
   fi
 fi


### PR DESCRIPTION
In the case the branch you're updating already has the changes of the
commit you're trying to add to the pr, the cherry pick will result in no
changes, and `cherry-pick --continue` will fail. In this case we now
error because it's likely unexpected. Theoretically we could
`--allow-empty` instead, so that the commits were still squashed
together on your main branch, but I imagine it's more common that this
was an error.

I hit this case when I reverted a commit on main, and then reverted the
revert, and tried to add it to my PR, in that case the PR already had
the change from before the revert on the main branch. The fix in my case
was to first rebase my PR to get the revert, and then update the PR.