### PR TITLE
Add --no-verify to updatepr

### DIFF
--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -97,12 +97,12 @@ if ! git -C "$worktree_dir" cherry-pick "$new_refspec^..$base_refspec"; then
 fi
 
 if [[ "$squash" == true ]]; then
-  git -C "$worktree_dir" commit -s --amend --fixup=HEAD~
+  git -C "$worktree_dir" commit -s --no-verify --amend --fixup=HEAD~
   git -C "$worktree_dir" rebase --interactive --autosquash HEAD~2
   git -C "$worktree_dir" push --force-with-lease --quiet || echo "warning: failed to force push '$branch_name'" >&2
 else
   git -C "$worktree_dir" push --quiet || echo "warning: failed to push '$branch_name'" >&2
 fi
 
-git rebase --interactive --exec "git commit --amend --fixup '$commit_to_update'" "$new_refspec"^
+git rebase --interactive --exec "git commit --no-verify --amend --fixup '$commit_to_update'" "$new_refspec"^
 git rebase --interactive --autosquash "$commit_to_update"^


### PR DESCRIPTION
These commits are kinda supposed to be transparent, so I think if you
want verification it should have happened when you were doing the
original commit on the main branch. Theoretically it could differ on the
new base but I don't think it's worth the penalty.