### PR TITLE
Add Basic stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ changes while still on the main branch.
   top of it.
 - All other options passed to `git submitpr` are passed through to the
   underlying `gh pr create` invocation
+- You can stack a PR using the --onto flag. e.g `git submitpr head --onto 
+head~2`
 - TODO: support auto-merge with `gh`
 
 ### git-updatepr

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -12,20 +12,32 @@ if [[ $# -gt 0 ]]; then
     commit_arg="$1"
     shift
   fi
+
+  if [[ ${1:-} == "--onto" ]]; then
+    onto_ref="$2"
+    shift
+    shift
+  fi
 fi
 
 commit="$(git rev-parse "$commit_arg")"
+upstream_ref="@{upstream}"
 branch_name="${GIT_PILE_PREFIX:-}$(git show --no-patch --format=%f "$commit" | tr '[:upper:]' '[:lower:]')"
+
+if [[ -n "${onto_ref:-}" ]]; then
+  base_branch_name="${GIT_PILE_PREFIX:-}$(git show --no-patch --format=%f "$onto_ref" | tr '[:upper:]' '[:lower:]')"
+  upstream_ref="$base_branch_name@{upstream}"
+fi
 
 if git show-ref --verify --quiet refs/heads/"$branch_name"; then
   echo "error: branch named '$branch_name' already exists" >&2
   exit 1
 fi
 
-branch_with_remote=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}")
+branch_with_remote=$(git rev-parse --abbrev-ref --symbolic-full-name "$upstream_ref")
 remote_branch_name="${branch_with_remote#*/}"
 
-git branch --no-track "$branch_name" "@{upstream}"
+git branch --no-track "$branch_name" "$upstream_ref"
 
 worktree_name=$(git roothash)
 readonly worktree_dir="$HOME/.cache/git-pile/$worktree_name"


### PR DESCRIPTION
Adds the --onto flag that changes the base branch. I've been using this with squashing on GitHub.com and still found I need to rebase PRs every now and again, to get the UI to reflect the correct changes. Discussed in #3 