### PR TITLE
Abort rebase if continue fails

### DIFF
--- a/bin/git-rebasepr
+++ b/bin/git-rebasepr
@@ -30,7 +30,10 @@ branch_with_remote=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream
 # TODO: Might have to pass -i here sometimes
 if ! git -C "$worktree_dir" rebase "$branch_with_remote"; then
   if git -C "$worktree_dir" mergetool; then
-    GIT_EDITOR=true git -C "$worktree_dir" rebase --continue
+    if ! GIT_EDITOR=true git -C "$worktree_dir" rebase --continue; then
+      git -C "$worktree_dir" rebase --abort
+      exit 1
+    fi
   else
     git -C "$worktree_dir" rebase --abort
     exit 1


### PR DESCRIPTION
If mergetool succeeds but somehow the conflicting files are still marked
as unresolved, it leaves the checkout in a bad state. Now it at least
aborts the rebase. I don't know how it's possible to have a successful
mergetool with unresolved conflicts but I haven't investigated. The 1
log I have seen shows the conflicts were resolved with rerere, but then
the continue still failed.
