### PR TITLE
Improve submitting via the web

### DIFF
--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -102,10 +102,11 @@ cleanup_remote_branch() {
 
 error_file=$(mktemp)
 if git -C "$worktree_dir" remote get-url mine 2>/dev/null && git -C "$worktree_dir" push --quiet --set-upstream mine "$branch_name"; then
+  # TODO: 'origin' might not be the only option
+  origin_url=$(git -C "$worktree_dir" remote get-url origin)
   # TODO: does gh not support -C either?
   pushd "$worktree_dir" >/dev/null
-  # TODO: pass --repo with value from origin?
-  gh pr create --web
+  gh pr create --web --repo "$origin_url" --base "$remote_branch_name" || cleanup_remote_branch
   popd >/dev/null
 elif git -C "$worktree_dir" push --quiet --set-upstream origin "$branch_name" 2> "$error_file"; then
   # TODO: does gh not support -C either?


### PR DESCRIPTION
This sets the remote and base branch assuming you're doing a fork
workflow. Technically you might not always be doing that even though it
is a fork, but this is probably the right default
