### PR TITLE
Add --signoff to main branch rebase after updatepr

### DIFF
--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -108,5 +108,5 @@ else
   git -C "$worktree_dir" push --quiet || echo "warning: failed to push '$branch_name'" >&2
 fi
 
-git rebase --quiet --interactive --exec "git commit --no-verify --amend --fixup '$commit_to_update'" "$new_refspec"^
+git rebase --quiet --interactive --exec "git commit --signoff --no-verify --amend --fixup '$commit_to_update'" "$new_refspec"^
 git rebase --quiet --interactive --autosquash "$commit_to_update"^


### PR DESCRIPTION
Otherwise if you have a git hook that verifies this it might fail if you
didn't signoff, when it doesn't matter since the commit will go away
after the squash anyways.
