### PR TITLE
Skip hooks when rebasing PRs

### DIFF
--- a/bin/git-rebasepr
+++ b/bin/git-rebasepr
@@ -40,4 +40,5 @@ if ! git -C "$worktree_dir" rebase "$branch_with_remote"; then
   fi
 fi
 
-git -C "$worktree_dir" push --force-with-lease --quiet
+# TODO: this skips push hooks, not sure if good? maybe pushing in the main repo would be better
+git -C "$worktree_dir" push --force-with-lease --quiet --no-verify


### PR DESCRIPTION
I pushed on a repo that had some push hooks, but since this was
happening in the worktree, the required dependencies to run them weren't
setup.
