### PR TITLE
Add git-replacepr

### DIFF
--- a/bin/git-replacepr
+++ b/bin/git-replacepr
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -n "${GIT_PILE_VERBOSE:-}" ]]; then
+  set -x
+fi
+
+export GIT_SEQUENCE_EDITOR=true
+
+readonly commit_arg=${1:-HEAD}
+commit="$(git rev-parse "$commit_arg")"
+
+branch_name="$(git pilebranchname "$commit_arg")"
+if ! git show-ref --quiet "$branch_name"; then
+  echo "error: branch '$branch_name' doesn't exist" >&2
+  exit 1
+fi
+
+worktree_dir="$(git pileworktreepath)"
+if [[ ! -d "$worktree_dir" ]]; then
+  git worktree add --quiet --force "$worktree_dir" "$branch_name"
+else
+  git -C "$worktree_dir" switch --quiet "$branch_name"
+fi
+
+_detach_branch() {
+  git -C "$worktree_dir" switch --detach --quiet
+}
+
+trap _detach_branch EXIT
+
+_ask() {
+  read -p "$1" -n 1 -r
+  if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+    echo "y"
+  elif [[ "$REPLY" =~ ^[Nn]$ ]]; then
+    echo "n"
+  else
+    echo >&2
+    _ask "$1"
+  fi
+}
+
+branch_with_remote=$(git -C "$worktree_dir" rev-parse --abbrev-ref --symbolic-full-name "@{upstream}")
+remote_name="${branch_with_remote%%/*}"
+remote_branch_name="${branch_with_remote#*/}"
+
+git -C "$worktree_dir" fetch --quiet "$remote_name" "$remote_branch_name"
+if ! git -C "$worktree_dir" diff --quiet "HEAD...@{upstream}"; then
+  git -C "$worktree_dir" diff "HEAD...@{upstream}"
+  answer=$(_ask "warning: upstream has new commits, would you like to pull those (or abort)? (y/n) ")
+  if [[ "$answer" == y ]]; then
+    git -C "$worktree_dir" pull
+  else
+    echo "warning: not updating PR, checkout '$branch_name', pull and try again" >&2
+    exit 1
+  fi
+fi
+
+upstream_branch=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}")
+merge_base=$(git -C "$worktree_dir" merge-base "$upstream_branch" HEAD)
+git -C "$worktree_dir" reset --hard "$merge_base"
+
+if ! git -C "$worktree_dir" cherry-pick "$commit" >/dev/null; then
+  # TODO: if you ctrl-c out of the merge tool, it doesn't return false it exists the script only hitting the trap, so the cherry pick is not aborted
+  if git -C "$worktree_dir" mergetool; then
+    if ! git -C "$worktree_dir" -c core.editor=true cherry-pick --continue; then
+      git -C "$worktree_dir" cherry-pick --abort || true
+      _detach_branch
+      echo "error: cherry picking failed, maybe there wasn't a commit to cherry pick?" >&2
+      exit 1
+    fi
+  else
+    git -C "$worktree_dir" cherry-pick --abort
+    _detach_branch
+    exit 1
+  fi
+fi
+
+git -C "$worktree_dir" push --force-with-lease --quiet || echo "warning: failed to force push '$branch_name'" >&2


### PR DESCRIPTION
This script can be used to entirely replace the contents of the
underlying branch with a new commit. This is useful if you've been
iterating on a PR, but then either want to squash it, or you for some
reason changed things on the main branch without mirroring those on the
remote branch.
