### PR TITLE
git-pilereset deletes worktree directory if exists

### DIFF
--- a/bin/git-pilereset
+++ b/bin/git-pilereset
@@ -7,7 +7,8 @@ if [[ -n "${GIT_PILE_VERBOSE:-}" ]]; then
 fi
 
 worktree_dir="$(git pileworktreepath)"
-git worktree remove --force "$worktree_dir"
+git worktree remove --force "$worktree_dir"  &> /dev/null || true
+/usr/bin/env rm "$worktree_dir" &> /dev/null || true
 
 # TODO: Should we optionally delete some branch?
 # TODO: Otherwise should we call it pileresetworktree?


### PR DESCRIPTION
Having a worktree that is not connected to the git repo is not handled by the current script.
By attempting to remove the directory after it is disconnected from the git repo, it covers this case.

fixes #44