### PR TITLE
Add --base to git-submitpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ changes while still on the main branch.
   underlying `gh pr create` invocation
 - You can stack a PR using the `--onto` flag. For example: `git submitpr
   --onto head~2`
+- You can submit a PR targeting another base branch using the `--base`
+  flag. For example: `git submitpr --base my-feature-branch`
 - If your GitHub repo supports auto-merge, you can pass
   `--merge-rebase`, `--merge-squash`, or `--merge` when creating the PR
   to enable auto-merge with the respective method. If enabling

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -24,6 +24,17 @@ if [[ $# -gt 0 ]]; then
     shift
     shift
   fi
+
+  if [[ ${1:-} == "--base" ]]; then
+    base="$2"
+    shift
+    shift
+  fi
+fi
+
+if [[ -n "${onto_ref:-}" && -n "${base:-}" ]]; then
+  echo "error: cannot specify both --onto and --base" >&2
+  exit 1
 fi
 
 commit="$(git rev-parse "$commit_arg")"
@@ -33,6 +44,8 @@ branch_name="$(git pilebranchname "$commit")"
 if [[ -n "${onto_ref:-}" ]]; then
   base_branch_name="$(git pilebranchname "$onto_ref")"
   upstream_ref="$base_branch_name@{upstream}"
+elif [[ -n "${base:-}" ]]; then
+  upstream_ref="$base@{upstream}"
 fi
 
 if git show-ref --verify --quiet refs/heads/"$branch_name"; then


### PR DESCRIPTION
This is helpful if you want to target your commits to a separate feature
branch, while still maintaining a local stack of all your combined
commits, even ones that aren't targeting that feature branch. It's still
up to you to handle rebasing these and resolving conflicts.
