### PR TITLE
Add --autostash to git updatepr

### DIFF
--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -109,5 +109,5 @@ else
   git -C "$worktree_dir" push --quiet || echo "warning: failed to push '$branch_name'" >&2
 fi
 
-git rebase --quiet --interactive --exec "git commit --signoff --no-verify --amend --fixup '$commit_to_update'" "$new_refspec"^
-git rebase --quiet --interactive --autosquash "$commit_to_update"^
+git rebase --quiet --interactive --autostash --exec "git commit --signoff --no-verify --amend --fixup '$commit_to_update'" "$new_refspec"^
+git rebase --quiet --interactive --autostash --autosquash "$commit_to_update"^


### PR DESCRIPTION
If you have other changes this can fail with:

```
$ git updatepr HEAD~1
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.
```

I never saw this because I globally have `rebase.autostash true` in my
gitconfig.
