### PR TITLE
Add GitLab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ brew install keith/formulae/git-pile
 
 [template]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
 
+### GitLab support
+
+- You can use `git-pile` with GitLab. Enable GitLab mode by running
+ `git config pile.gitlabModeEnabled true`. Also set your GitLab URL via
+ `git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/merge_requests/"`
+
 ## Advanced usage
 
 ### Squash and merge

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ brew install keith/formulae/git-pile
 
 - You can use `git-pile` with GitLab. Enable GitLab mode by running
  `git config pile.gitlabModeEnabled true`. Also set your GitLab URL via
- `git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/merge_requests/"`
+ `git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/-/merge_requests/new"`
 
 ## Advanced usage
 

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -13,7 +13,7 @@ gitlab_url=$(git config --default '' pile.gitlabMergeRequestsURL)
 
 if [[ $gitlab_mode_enabled = true ]]; then
   if [[ -z $gitlab_url ]]; then
-    echo "error: gitlab_mode enabled, but pile.gitlabMergeRequestsURL is not set" >&2
+    echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/merge_requests/' to configure it" >&2
     exit 1
   fi
 else

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -8,9 +8,19 @@ if [[ -n "${GIT_PILE_VERBOSE:-}" ]]; then
   quiet_arg=""
 fi
 
-if ! command -v gh > /dev/null; then
-  echo "error: missing gh, install here: https://cli.github.com" >&2
-  exit 1
+gitlab_mode_enabled=$(git config --default false --type=bool pile.gitlabModeEnabled)
+gitlab_url=$(git config --default '' pile.gitlabMergeRequestsURL)
+
+if [[ $gitlab_mode_enabled = true ]]; then
+  if [[ -z $gitlab_url ]]; then
+    echo "error: gitlab_mode enabled, but pile.gitlabMergeRequestsURL is not set" >&2
+    exit 1
+  fi
+else
+  if ! command -v gh > /dev/null; then
+    echo "error: missing gh, install here: https://cli.github.com" >&2
+    exit 1
+  fi
 fi
 
 commit_arg=HEAD
@@ -115,13 +125,21 @@ cleanup_remote_branch() {
   exit 1
 }
 
+gitlab_create_pr() {
+  native_open "$gitlab_url/new?merge_request[source_branch]=$1&merge_request[target_branch]=$2"
+}
+
 error_file=$(mktemp)
 if git -C "$worktree_dir" remote get-url mine 2>/dev/null && git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream mine "$branch_name"; then
   # TODO: 'origin' might not be the only option
   origin_url=$(git -C "$worktree_dir" remote get-url origin)
   # TODO: does gh not support -C either?
   pushd "$worktree_dir" >/dev/null
-  gh pr create --web --repo "$origin_url" --base "$remote_branch_name"
+  if [[ $gitlab_mode_enabled = true ]]; then
+    gitlab_create_pr "$branch_name" "$remote_branch_name"
+  else
+    gh pr create --web --repo "$origin_url" --base "$remote_branch_name"
+  fi
   popd >/dev/null
 elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$branch_name" 2> "$error_file"; then
   # TODO: does gh not support -C either?
@@ -162,17 +180,21 @@ elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$
     esac
   done
 
-  if url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
-    # TODO: should I set subject and body?
-    if [[ -n "$merge_arg" ]] && ! gh pr merge "$url" --auto "$merge_arg"; then
-      native_open "$url"
-      echo "warning: failed to auto-merge PR with $merge_arg" >&2
-      exit 1
-    fi
-
-    native_open "$url"
+  if [[ $gitlab_mode_enabled = true ]]; then
+    gitlab_create_pr "$branch_name" "$remote_branch_name"
   else
-    cleanup_remote_branch
+    if url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
+      # TODO: should I set subject and body?
+      if [[ -n "$merge_arg" ]] && ! gh pr merge "$url" --auto "$merge_arg"; then
+        native_open "$url"
+        echo "warning: failed to auto-merge PR with $merge_arg" >&2
+        exit 1
+      fi
+
+      native_open "$url"
+    else
+      cleanup_remote_branch
+    fi
   fi
 
   popd >/dev/null

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -13,7 +13,7 @@ gitlab_url=$(git config --default '' pile.gitlabMergeRequestsURL)
 
 if [[ $gitlab_mode_enabled = true ]]; then
   if [[ -z $gitlab_url ]]; then
-    echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/merge_requests/' to configure it" >&2
+    echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL \"https://gitlab.com/{group}/{project}/-/merge_requests/new\"' to configure it" >&2
     exit 1
   fi
 else
@@ -126,7 +126,7 @@ cleanup_remote_branch() {
 }
 
 gitlab_create_pr() {
-  native_open "$gitlab_url/new?merge_request[source_branch]=$1&merge_request[target_branch]=$2"
+  native_open "$gitlab_url?merge_request[source_branch]=$1&merge_request[target_branch]=$2"
 }
 
 error_file=$(mktemp)


### PR DESCRIPTION
Hello!
I have been using this approach for a few years, it works great!

My org uses GitLab, so I added opt-in support for it, basically it opens a browser to create PR instead of using `gh`. This is fully optional, and can be enabled via git config flag (also you should specify GitLab URL to make it work).

I would be happy to see it merged in main repo instead of supporting fork.