### PR TITLE
Automatically derive GitLab merge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,7 @@ brew install keith/formulae/git-pile
 ### GitLab support
 
 - You can use `git-pile` with GitLab. Enable GitLab mode by running
- `git config pile.gitlabModeEnabled true`. It will use GitLab merge
- request URL from origin by default, but if it does not work for you, please use
- `git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/-/merge_requests/new"`
- to set it manually.
+ `git config pile.gitlabModeEnabled true`.
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,10 @@ brew install keith/formulae/git-pile
 ### GitLab support
 
 - You can use `git-pile` with GitLab. Enable GitLab mode by running
- `git config pile.gitlabModeEnabled true`. Also set your GitLab URL via
+ `git config pile.gitlabModeEnabled true`. It will use GitLab merge
+ request URL from origin by default, but if it does not work for you, please use
  `git config pile.gitlabMergeRequestsURL "https://gitlab.com/{group}/{project}/-/merge_requests/new"`
+ to set it manually.
 
 ## Advanced usage
 

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -9,22 +9,18 @@ if [[ -n "${GIT_PILE_VERBOSE:-}" ]]; then
 fi
 
 gitlab_mode_enabled=$(git config --default false --type=bool pile.gitlabModeEnabled)
-gitlab_url=$(git config --default '' pile.gitlabMergeRequestsURL)
 
 if [[ $gitlab_mode_enabled = true ]]; then
-  if [[ -z "$gitlab_url" ]]; then
-    origin_url=$(git remote get-url origin | sed 's/\.git$//')
-    ssh_pattern="^git@(git\.)?([^:]+):(.+)$"
-    https_pattern="^https:\/\/(.+)$"
-    if [[ $origin_url =~ $ssh_pattern ]]; then
-      gitlab_url="https://${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/-/merge_requests/new"
-    elif [[ $origin_url =~ $https_pattern ]]; then
-      gitlab_url="https://${BASH_REMATCH[1]}/-/merge_requests/new"
-    else
-      echo "error: Cannot derive GitLab merge request URL from origin"
-      echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL \"https://gitlab.com/{group}/{project}/-/merge_requests/new\"' to configure it" >&2
-      exit 1
-    fi
+  origin_url=$(git remote get-url origin | sed 's/\.git$//')
+  ssh_pattern="^git@(git\.)?([^:]+):(.+)$"  # git@git.gitlab.companydomain.app:mobile/ios
+  https_pattern="^https:\/\/(.+)$"          # https://gitlab.companydomain.app/mobile/ios
+  if [[ $origin_url =~ $ssh_pattern ]]; then
+    gitlab_url="https://${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/-/merge_requests/new"
+  elif [[ $origin_url =~ $https_pattern ]]; then
+    gitlab_url="https://${BASH_REMATCH[1]}/-/merge_requests/new"
+  else
+    echo "error: Cannot derive GitLab merge request URL from origin"
+    exit 1
   fi
 else
   if ! command -v gh > /dev/null; then

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -12,9 +12,19 @@ gitlab_mode_enabled=$(git config --default false --type=bool pile.gitlabModeEnab
 gitlab_url=$(git config --default '' pile.gitlabMergeRequestsURL)
 
 if [[ $gitlab_mode_enabled = true ]]; then
-  if [[ -z $gitlab_url ]]; then
-    echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL \"https://gitlab.com/{group}/{project}/-/merge_requests/new\"' to configure it" >&2
-    exit 1
+  if [[ -z "$gitlab_url" ]]; then
+    origin_url=$(git remote get-url origin | sed 's/\.git$//')
+    ssh_pattern="^git@(git\.)?([^:]+):(.+)$"
+    https_pattern="^https:\/\/(.+)$"
+    if [[ $origin_url =~ $ssh_pattern ]]; then
+      gitlab_url="https://${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/-/merge_requests/new"
+    elif [[ $origin_url =~ $https_pattern ]]; then
+      gitlab_url="https://${BASH_REMATCH[1]}/-/merge_requests/new"
+    else
+      echo "error: Cannot derive GitLab merge request URL from origin"
+      echo "error: GitLab is enabled, but no URL is set, run 'git config pile.gitlabMergeRequestsURL \"https://gitlab.com/{group}/{project}/-/merge_requests/new\"' to configure it" >&2
+      exit 1
+    fi
   fi
 else
   if ! command -v gh > /dev/null; then


### PR DESCRIPTION
Derive GitLab merge URL from remote origin as discussed in https://github.com/keith/git-pile/pull/56#discussion_r1323261816.

Examples to check on regex101:
```
ssh_pattern = ^git@(git\.)?([^:]+):(.+)$

git@gitlab.com:companyname/ios
git@git.gitlab.companydomain.app:mobile/ios
git@gitlab.com:companyname/sre/protobuf
```

```
https_pattern = ^https:\/\/(.+)$

https://gitlab.com/companyname/ios
https://gitlab.companydomain.app/mobile/ios
https://gitlab.com/companyname/sre/protobuf
```