### PR TITLE
Remove .lock from the end of branch names

### DIFF
--- a/bin/git-pilebranchname
+++ b/bin/git-pilebranchname
@@ -4,5 +4,5 @@ set -euo pipefail
 
 readonly ref=$1
 
-branch_name="${GIT_PILE_PREFIX:-}$(git show --no-patch --no-show-signature --format=%f "$ref" | tr '[:upper:]' '[:lower:]' | sed 's/^\.*//')"
+branch_name="${GIT_PILE_PREFIX:-}$(git show --no-patch --no-show-signature --format=%f "$ref" | tr '[:upper:]' '[:lower:]' | sed -e 's/^\.*//' -e 's/\.lock$/-lock/')"
 echo "$branch_name"


### PR DESCRIPTION
This gets rejected by git https://github.com/git/git/blob/bc5204569f7db44d22477485afd52ea410d83743/refs.c#L162
