### PR TITLE
Add support for branch name in updatepr

### DIFF
--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -40,11 +40,11 @@ fi
 
 # Get the commit to update and the branch name
 if git show-ref --quiet --verify "refs/heads/$sha_or_branch_to_update"; then
-  commit_to_update=$(git rev-parse --verify "$sha_or_branch_to_update" 2>/dev/null)
   branch_name="$sha_or_branch_to_update"
+  commit_to_update=$(git rev-parse --verify "$branch_name" 2>/dev/null)
 else
   commit_to_update="$sha_or_branch_to_update"
-  branch_name="$(git pilebranchname "$sha_or_branch_to_update")"
+  branch_name="$(git pilebranchname "$commit_to_update")"
 fi
 
 # Check if we got a valid SHA

--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -13,20 +13,8 @@ fi
 
 export GIT_SEQUENCE_EDITOR=true
 
-# Check if the input is a branch name
-if git show-ref --quiet --verify "refs/heads/$1"; then
-  branch_name="$1"
-  commit_to_update=$(git rev-parse --verify "$1" 2>/dev/null)
-else
-  branch_name="$(git pilebranchname "$1")"
-  commit_to_update="$1"
-fi
-
-# Check if we got a valid SHA
-if ! git cat-file -e "$commit_to_update" 2>/dev/null; then
-  echo "error: invalid commit sha or branch name: '$1'" >&2
-  exit 1
-fi
+readonly sha_or_branch_to_update=$1
+shift
 
 squash=false
 for arg in "$@"
@@ -50,6 +38,22 @@ if [[ "$new_refspec" != "$base_refspec" ]]; then
   exit 1
 fi
 
+# Get the commit to update and the branch name
+if git show-ref --quiet --verify "refs/heads/$sha_or_branch_to_update"; then
+  commit_to_update=$(git rev-parse --verify "$sha_or_branch_to_update" 2>/dev/null)
+  branch_name="$sha_or_branch_to_update"
+else
+  commit_to_update="$sha_or_branch_to_update"
+  branch_name="$(git pilebranchname "$sha_or_branch_to_update")"
+fi
+
+# Check if we got a valid SHA
+if ! git cat-file -e "$commit_to_update" 2>/dev/null; then
+  echo "error: invalid commit sha or branch name: '$1'" >&2
+  exit 1
+fi
+
+# Check if we got a valid branch
 if ! git show-ref --quiet "$branch_name"; then
   echo "error: branch '$branch_name' doesn't exist" >&2
   exit 1

--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -42,20 +42,17 @@ fi
 if git show-ref --quiet --verify "refs/heads/$sha_or_branch_to_update"; then
   branch_name="$sha_or_branch_to_update"
   commit_to_update=$(git rev-parse --verify "$branch_name" 2>/dev/null)
-else
+elif ! git cat-file -e "$sha_or_branch_to_update" 2>/dev/null; then
   commit_to_update="$sha_or_branch_to_update"
   branch_name="$(git pilebranchname "$commit_to_update")"
-fi
 
-# Check if we got a valid SHA
-if ! git cat-file -e "$commit_to_update" 2>/dev/null; then
-  echo "error: invalid commit sha or branch name: '$1'" >&2
-  exit 1
-fi
-
-# Check if we got a valid branch
-if ! git show-ref --quiet "$branch_name"; then
-  echo "error: branch '$branch_name' doesn't exist" >&2
+  # Check if we got a valid branch
+  if ! git show-ref --quiet "$branch_name"; then
+    echo "error: branch '$branch_name' doesn't exist" >&2
+    exit 1
+  fi
+else
+  echo "error: invalid commit sha or branch name: '$sha_or_branch_to_update'" >&2
   exit 1
 fi
 

--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -13,8 +13,20 @@ fi
 
 export GIT_SEQUENCE_EDITOR=true
 
-readonly commit_to_update=$1
-shift
+# Check if the input is a branch name
+if git show-ref --quiet --verify "refs/heads/$1"; then
+  branch_name="$1"
+  commit_to_update=$(git rev-parse --verify "$1" 2>/dev/null)
+else
+  branch_name="$(git pilebranchname "$1")"
+  commit_to_update="$1"
+fi
+
+# Check if we got a valid SHA
+if ! git cat-file -e "$commit_to_update" 2>/dev/null; then
+  echo "error: invalid commit sha or branch name: '$1'" >&2
+  exit 1
+fi
 
 squash=false
 for arg in "$@"
@@ -38,12 +50,6 @@ if [[ "$new_refspec" != "$base_refspec" ]]; then
   exit 1
 fi
 
-if ! git cat-file -e "$commit_to_update" 2> /dev/null; then
-  echo "error: invalid commit sha: '$commit_to_update'" >&2
-  exit 1
-fi
-
-branch_name="$(git pilebranchname "$commit_to_update")"
 if ! git show-ref --quiet "$branch_name"; then
   echo "error: branch '$branch_name' doesn't exist" >&2
   exit 1

--- a/bin/git-updatepr
+++ b/bin/git-updatepr
@@ -7,7 +7,7 @@ if [[ -n "${GIT_PILE_VERBOSE:-}" ]]; then
 fi
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <new_sha> [--squash] [<sha_to_update>]" >&2
+  echo "usage: $0 <sha_or_branch_to_update> [--squash]" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Makes it possible to pass a branch name instead of a commit sha. This is useful so you can pass the branch name explicitly if you created the branch manually instead of using git pile (as git pile would try to get the branch name from the commit message)