### PR TITLE
Add error when fzy is not found

### DIFF
--- a/bin/git-absorb
+++ b/bin/git-absorb
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+RED = "\033[91m"
+RESET = "\033[0m"
 
 class _GitError(Exception):
     pass
@@ -139,6 +141,9 @@ def _main(squash: bool, commit_args: List[str]) -> None:
             selected_line = subprocess.check_output(
                 ["fzy"], input="\n".join(sorted(option_lines)).encode()
             ).decode()
+        except FileNotFoundError:
+            sys.exit(f"{RED}error: 'fzy' was not found. Please install 'fzy' and make it available in your $PATH.\n"
+                     f"Learn more at: https://github.com/keith/git-pile/blob/main/README.md#manually{RESET}")
         except subprocess.CalledProcessError:
             sys.exit(1)
 


### PR DESCRIPTION
Adds an actionable message to the output of absorb when `fzy` is missing and required:

![image](https://github.com/user-attachments/assets/aee3987a-6eee-4490-8105-8ef323cca05c)


previous:

![image](https://github.com/user-attachments/assets/f968fb0f-0bb6-4fc9-a628-d077ec3c837e)
