### PR TITLE
Call `mergetool .` while rebasing

### DIFF
--- a/bin/git-rebasepr
+++ b/bin/git-rebasepr
@@ -48,7 +48,7 @@ trap _detach_branch EXIT
 branch_with_remote=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}")
 if ! git -C "$worktree_dir" rebase "$branch_with_remote" "${rebase_args[@]:---}"; then
   # TODO: if multiple commits conflict this only handles the first one, after the continue it fails again, we need another mergetool call, in a loop
-  if git -C "$worktree_dir" mergetool; then
+  if git -C "$worktree_dir" mergetool .; then
     if ! GIT_EDITOR=true git -C "$worktree_dir" rebase --continue; then
       git -C "$worktree_dir" rebase --abort
       exit 1


### PR DESCRIPTION
For some reason during the rebase workflow, `git mergetool` was saying "no files need merging" but `git rebase --continue` failed with "<file> needs merge", which seemed contradictory.

https://stackoverflow.com/a/49395242 says `git mergetool .` worked for them and it did for me too, although it's not clear why, but I figure it doesn't hurt either.