### PR TITLE
Add land-pr command

### DIFF
--- a/bin/git-landpr
+++ b/bin/git-landpr
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+import argparse
+import collections
+import subprocess
+
+
+class _GitError(Exception):
+    pass
+
+
+@dataclass
+class _Metadata:
+    commit: str
+    url: str
+    base: str | None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("commit", help="The commit to land")
+    return parser
+
+
+def _run_git_command(args: list[str]) -> str:
+    try:
+        output: bytes = subprocess.check_output(["git"] + args)
+        # TODO: got an exception here at some point
+        return output.strip().decode("utf-8")
+    except subprocess.CalledProcessError:
+        raise _GitError()
+    except UnicodeDecodeError:
+        print(f"error: output was {output}")
+        raise
+
+
+def _get_possible_shas() -> list[str]:
+    return _run_git_command(
+        ["log", "--no-show-signature", "--pretty=%H", "@{upstream}..HEAD"]
+    ).splitlines()
+
+
+def _get_metadata(commit: str) -> _Metadata:
+    try:
+        notes = _run_git_command(["notes", "show", commit]).strip()
+    except _GitError:
+        raise SystemExit(f"error: no notes found for {commit}")
+
+    url = None
+    base = None
+    for line in notes.splitlines():
+        print("1", line)
+        if line.startswith("Pile-URL: "):
+            url = line[len("Pile-URL: ") :]
+        if line.startswith("Pile-Base: "):
+            base = line[len("Pile-Base: ") :]
+
+    if not url:
+        raise SystemExit(f"URL not found in notes: {notes}")
+
+    return _Metadata(commit, url, base)
+
+
+def _main(commit: str) -> None:
+    # Normalize HEAD -> commit, etc
+    commit = _run_git_command(["rev-parse", commit])
+
+    metadata = _get_metadata(commit)
+
+    branch_being_merged = _run_git_command(["pilebranchname", commit])
+    print("2", branch_being_merged)
+
+    subprocess.check_call(["gh", "pr", "merge", metadata.url, "--squash"])
+    try:
+        # TODO: This can fail for a conflict, we should allow resolution here, which might just be skipping
+        _run_git_command(["pull"])
+    except _GitError:
+        raise SystemExit(f"error: failed to pull, dependent PRs have not be rebased")
+
+    _run_git_command(["notes", "remove", commit, "--ignore-missing"])
+
+    potential_rebases = collections.defaultdict(list)
+    for commit in _get_possible_shas():
+        try:
+            metadata = _get_metadata(commit)
+        except _GitError:
+            continue
+
+        if not metadata.base:
+            continue
+
+        potential_rebases[metadata.base].append(metadata)
+
+    queue = collections.deque([branch_being_merged])
+    while queue:
+        base = queue.popleft()
+        while metadatas := potential_rebases.get(base):
+            for metadata in metadatas:
+                # TODO: second level rebases don't work, rebasepr doesn't respect --onto branches
+                if base == branch_being_merged:
+                    _run_git_command(["rebasepr", metadata.commit])
+                else:
+                    _run_git_command(["rebasepr", metadata.commit, base])
+
+                base = _run_git_command(["pilebranchname", metadata.commit])
+                queue.append(base)
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
+    _main(args.commit)

--- a/bin/git-landpr
+++ b/bin/git-landpr
@@ -1,20 +1,13 @@
 #!/usr/bin/env python3
 
-from dataclasses import dataclass
 import argparse
 import collections
+import json
 import subprocess
 
 
 class _GitError(Exception):
     pass
-
-
-@dataclass
-class _Metadata:
-    commit: str
-    url: str
-    base: str | None
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -26,7 +19,6 @@ def _build_parser() -> argparse.ArgumentParser:
 def _run_git_command(args: list[str]) -> str:
     try:
         output: bytes = subprocess.check_output(["git"] + args)
-        # TODO: got an exception here at some point
         return output.strip().decode("utf-8")
     except subprocess.CalledProcessError:
         raise _GitError()
@@ -41,70 +33,89 @@ def _get_possible_shas() -> list[str]:
     ).splitlines()
 
 
-def _get_metadata(commit: str) -> _Metadata:
-    try:
-        notes = _run_git_command(["notes", "show", commit]).strip()
-    except _GitError:
-        raise SystemExit(f"error: no notes found for {commit}")
+def _get_branch_name(commit: str) -> str:
+    return _run_git_command(["pilebranchname", commit])
 
-    url = None
-    base = None
-    for line in notes.splitlines():
-        print("1", line)
-        if line.startswith("Pile-URL: "):
-            url = line[len("Pile-URL: ") :]
-        if line.startswith("Pile-Base: "):
-            base = line[len("Pile-Base: ") :]
 
-    if not url:
-        raise SystemExit(f"URL not found in notes: {notes}")
+def _get_pr_url(commit: str) -> str:
+    """Get the PR URL for a commit by finding the PR with a matching head branch."""
+    branch_name = _get_branch_name(commit)
+    result = subprocess.run(
+        ["gh", "pr", "list", "--head", branch_name, "--json", "url", "--limit", "1"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"error: failed to find PR for branch {branch_name}, {result.stderr.strip()}"
+        )
 
-    return _Metadata(commit, url, base)
+    prs = json.loads(result.stdout)
+    if not prs:
+        raise SystemExit(f"error: no PR found for branch {branch_name}")
+
+    return prs[0]["url"]
+
+
+def _get_prs_targeting_base(base_branch: str) -> list[str]:
+    """Get all PR head branches that target the given base branch."""
+    output = subprocess.check_output(
+        ["gh", "pr", "list", "--base", base_branch, "--json", "headRefName"],
+    )
+    prs = json.loads(output)
+    return [pr["headRefName"] for pr in prs]
+
+
+def _find_commit_for_branch(branch_name: str, possible_shas: list[str]) -> str | None:
+    """Find the local commit that corresponds to a branch name."""
+    for sha in possible_shas:
+        if _get_branch_name(sha) == branch_name:
+            return sha
+    return None
 
 
 def _main(commit: str) -> None:
     # Normalize HEAD -> commit, etc
     commit = _run_git_command(["rev-parse", commit])
 
-    metadata = _get_metadata(commit)
+    pr_url = _get_pr_url(commit)
+    branch_being_merged = _get_branch_name(commit)
 
-    branch_being_merged = _run_git_command(["pilebranchname", commit])
-    print("2", branch_being_merged)
-
-    subprocess.check_call(["gh", "pr", "merge", metadata.url, "--squash"])
+    subprocess.check_call(["gh", "pr", "merge", pr_url, "--squash"])
     try:
-        # TODO: This can fail for a conflict, we should allow resolution here, which might just be skipping
         _run_git_command(["pull"])
     except _GitError:
-        raise SystemExit(f"error: failed to pull, dependent PRs have not be rebased")
+        raise SystemExit("error: failed to pull, dependent PRs have not been rebased")
 
-    _run_git_command(["notes", "remove", commit, "--ignore-missing"])
-
-    potential_rebases = collections.defaultdict(list)
-    for commit in _get_possible_shas():
-        try:
-            metadata = _get_metadata(commit)
-        except _GitError:
-            continue
-
-        if not metadata.base:
-            continue
-
-        potential_rebases[metadata.base].append(metadata)
+    # Build a map of branch names to their local commits
+    possible_shas = _get_possible_shas()
 
     queue = collections.deque([branch_being_merged])
+    processed = set()
+
     while queue:
         base = queue.popleft()
-        while metadatas := potential_rebases.get(base):
-            for metadata in metadatas:
-                # TODO: second level rebases don't work, rebasepr doesn't respect --onto branches
-                if base == branch_being_merged:
-                    _run_git_command(["rebasepr", metadata.commit])
-                else:
-                    _run_git_command(["rebasepr", metadata.commit, base])
+        if base in processed:
+            continue
+        processed.add(base)
 
-                base = _run_git_command(["pilebranchname", metadata.commit])
-                queue.append(base)
+        # Find all PRs that target this base branch
+        dependent_branches = _get_prs_targeting_base(base)
+
+        for dep_branch in dependent_branches:
+            # Find the local commit for this dependent branch
+            dep_commit = _find_commit_for_branch(dep_branch, possible_shas)
+            if not dep_commit:
+                continue
+
+            # Rebase the dependent PR
+            if base == branch_being_merged:
+                _run_git_command(["rebasepr", dep_commit])
+            else:
+                _run_git_command(["rebasepr", dep_commit, base])
+
+            # Add this branch to the queue to process its dependents
+            queue.append(dep_branch)
 
 
 if __name__ == "__main__":

--- a/bin/git-rebasepr
+++ b/bin/git-rebasepr
@@ -17,10 +17,10 @@ do
       ;;
     *)
       if [[ -n "$commit" ]]; then
-        echo "error: multiple commit args passed, '$commit' and '$arg'" >&2
-        exit 1
+        rebase_args+=("$arg")
+      else
+        commit="$arg"
       fi
-      commit="$arg"
       ;;
   esac
 done

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -135,6 +135,16 @@ gitlab_create_pr() {
   native_open "$gitlab_url?merge_request[source_branch]=$1&merge_request[target_branch]=$2"
 }
 
+store_and_open_url() {
+  if [[ -n "${onto_ref:-}" ]]; then
+    git notes add -f "$commit" -m "Pile-URL: $1
+Pile-Base: $(git pilebranchname "$onto_ref")"
+  else
+    git notes add -f "$commit" -m "Pile-URL: $1"
+  fi
+  native_open "$1"
+}
+
 error_file=$(mktemp)
 if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
   if git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream mine "$branch_name"; then
@@ -146,7 +156,7 @@ if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
       gitlab_create_pr "$branch_name" "$remote_branch_name"
     else
       if url=$(gh pr create --fill --repo "$origin_url" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
-        native_open "$url"
+        store_and_open_url "$url"
       fi
     fi
     popd >/dev/null
@@ -201,12 +211,12 @@ elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$
     if url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
       # TODO: should I set subject and body?
       if [[ -n "$merge_arg" ]] && ! gh pr merge "$url" --auto "$merge_arg"; then
-        native_open "$url"
+        store_and_open_url "$url"
         echo "warning: failed to auto-merge PR with $merge_arg" >&2
         exit 1
       fi
 
-      native_open "$url"
+      store_and_open_url "$url"
     else
       cleanup_remote_branch
     fi

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -135,16 +135,6 @@ gitlab_create_pr() {
   native_open "$gitlab_url?merge_request[source_branch]=$1&merge_request[target_branch]=$2"
 }
 
-store_and_open_url() {
-  if [[ -n "${onto_ref:-}" ]]; then
-    git notes add -f "$commit" -m "Pile-URL: $1
-Pile-Base: $(git pilebranchname "$onto_ref")"
-  else
-    git notes add -f "$commit" -m "Pile-URL: $1"
-  fi
-  native_open "$1"
-}
-
 error_file=$(mktemp)
 if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
   if git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream mine "$branch_name"; then
@@ -156,7 +146,7 @@ if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
       gitlab_create_pr "$branch_name" "$remote_branch_name"
     else
       if url=$(gh pr create --fill --repo "$origin_url" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
-        store_and_open_url "$url"
+        native_open "$url"
       fi
     fi
     popd >/dev/null
@@ -211,12 +201,12 @@ elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$
     if url=$(gh pr create "${body_args[@]}" --base "$remote_branch_name" "${pr_args[@]:---}" | grep github.com); then
       # TODO: should I set subject and body?
       if [[ -n "$merge_arg" ]] && ! gh pr merge "$url" --auto "$merge_arg"; then
-        store_and_open_url "$url"
+        native_open "$url"
         echo "warning: failed to auto-merge PR with $merge_arg" >&2
         exit 1
       fi
 
-      store_and_open_url "$url"
+      native_open "$url"
     else
       cleanup_remote_branch
     fi


### PR DESCRIPTION
This command makes working with dependent PR stacks a bit easier. When you use it to merge a PR, it squash merges it, pulls, and rebases all the PRs (that are mirrored as local commits) that depended on the landed PR (recursively). Since github automatically changes the base of the dependent PRs, this is all that is needed to drop the merged commit from their diff after github does that.