### PR TITLE
Abort cherry pick before detaching branch

### DIFF
--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -88,6 +88,7 @@ else
 fi
 
 _detach_branch() {
+  git -C "$worktree_dir" cherry-pick --abort || true
   git -C "$worktree_dir" switch --detach $quiet_arg
 }
 
@@ -97,14 +98,12 @@ if ! git -C "$worktree_dir" cherry-pick "$commit" >/dev/null; then
   # TODO: if you ctrl-c out of the merge tool, it doesn't return false it exists the script only hitting the trap, so the cherry pick is not aborted
   if git -C "$worktree_dir" mergetool; then
     if ! git -C "$worktree_dir" -c core.editor=true cherry-pick --continue; then
-      git -C "$worktree_dir" cherry-pick --abort || true
       _detach_branch
       git branch -D "$branch_name"
       echo "error: cherry picking failed, maybe there wasn't a commit to cherry pick?" >&2
       exit 1
     fi
   else
-    git -C "$worktree_dir" cherry-pick --abort
     _detach_branch
     git branch -D "$branch_name"
     exit 1

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -90,6 +90,7 @@ fi
 _detach_branch() {
   git -C "$worktree_dir" cherry-pick --abort || true
   git -C "$worktree_dir" switch --detach $quiet_arg
+  git branch -D "$branch_name"
 }
 
 trap _detach_branch EXIT
@@ -99,13 +100,11 @@ if ! git -C "$worktree_dir" cherry-pick "$commit" >/dev/null; then
   if git -C "$worktree_dir" mergetool; then
     if ! git -C "$worktree_dir" -c core.editor=true cherry-pick --continue; then
       _detach_branch
-      git branch -D "$branch_name"
       echo "error: cherry picking failed, maybe there wasn't a commit to cherry pick?" >&2
       exit 1
     fi
   else
     _detach_branch
-    git branch -D "$branch_name"
     exit 1
   fi
 fi
@@ -176,7 +175,6 @@ if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
   else
     echo "error: failed to create remote branch: $(cat "$error_file")" >&2
     _detach_branch
-    git branch -D "$branch_name"
     exit 1
   fi
 elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$branch_name" 2> "$error_file"; then
@@ -215,6 +213,5 @@ elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$
 else
   echo "error: failed to create remote branch: $(cat "$error_file")" >&2
   _detach_branch
-  git branch -D "$branch_name"
   exit 1
 fi

--- a/bin/git-submitpr
+++ b/bin/git-submitpr
@@ -87,24 +87,26 @@ else
   fi
 fi
 
-_detach_branch() {
-  git -C "$worktree_dir" cherry-pick --abort || true
-  git -C "$worktree_dir" switch --detach $quiet_arg
-  git branch -D "$branch_name"
+_cleanup_worktree() {
+  local status=$?
+
+  git -C "$worktree_dir" cherry-pick --abort >/dev/null 2>&1 || true
+  git -C "$worktree_dir" switch --detach $quiet_arg || true
+  if [[ $status -ne 0 ]]; then
+    git branch -D "$branch_name" || true
+  fi
 }
 
-trap _detach_branch EXIT
+trap _cleanup_worktree EXIT
 
 if ! git -C "$worktree_dir" cherry-pick "$commit" >/dev/null; then
   # TODO: if you ctrl-c out of the merge tool, it doesn't return false it exists the script only hitting the trap, so the cherry pick is not aborted
   if git -C "$worktree_dir" mergetool; then
     if ! git -C "$worktree_dir" -c core.editor=true cherry-pick --continue; then
-      _detach_branch
       echo "error: cherry picking failed, maybe there wasn't a commit to cherry pick?" >&2
       exit 1
     fi
   else
-    _detach_branch
     exit 1
   fi
 fi
@@ -174,7 +176,6 @@ if git -C "$worktree_dir" remote get-url mine >/dev/null 2>&1; then
     popd >/dev/null
   else
     echo "error: failed to create remote branch: $(cat "$error_file")" >&2
-    _detach_branch
     exit 1
   fi
 elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$branch_name" 2> "$error_file"; then
@@ -212,6 +213,5 @@ elif git -C "$worktree_dir" push --no-verify $quiet_arg --set-upstream origin "$
   popd >/dev/null
 else
   echo "error: failed to create remote branch: $(cat "$error_file")" >&2
-  _detach_branch
   exit 1
 fi


### PR DESCRIPTION
One case where the previous logic wasn't enough was if you ctrl-c'd when
the mergetool invocation was asking you about a deleted file. In that
case only the detach would happen:

```
+ git -C /Users/ksmiley/.cache/git-pile/2c8aee4d0f715033a1e04fd216df2b96 mergetool
Merging:
tests/BUILD.bazel

Deleted merge conflict for 'tests/BUILD.bazel':
  {local}: deleted
  {remote}: modified file
Use (m)odified or (d)eleted file, or (a)bort? ^C++ _detach_branch
++ git -C /Users/ksmiley/.cache/git-pile/2c8aee4d0f715033a1e04fd216df2b96 switch --detach
fatal: cannot switch branch while cherry-picking
Consider "git cherry-pick --quit" or "git worktree add".
```

This is slightly less strict about the one cherry pick abort case, and
now runs under some other cases too but should be fine
